### PR TITLE
Update celestrondriver.cpp

### DIFF
--- a/drivers/telescope/celestrondriver.cpp
+++ b/drivers/telescope/celestrondriver.cpp
@@ -793,7 +793,7 @@ bool CelestronDriver::set_location(double longitude, double latitude)
     cmd[5] = static_cast<char>(abs(long_d));       // not sure how the conversion from int to char will work for longtitudes > 127
     cmd[6] = static_cast<char>(long_m);
     cmd[7] = static_cast<char>(long_s);
-    cmd[8] = long_d > 0 ? 0 : 1;
+    cmd[8] = long_d >= 0 ? 0 : 1;	 //Error fixed here (was cmd[8] = long_d >= 0 ? 0 : 1;) which was wrong for < 1 degree East.
 
     set_sim_response("#");
     return send_command(cmd, 9, response, 1, false, true);


### PR DESCRIPTION
The code tests if the degrees passed to it are > 0 if they are it sends East to the mount, if less than 0 it sends West, for location less than 1 degree East the code was wrongly sending West because the degrees are 0. My location is 000:07:24 East so I noticed the error. Checking for >= fixes the issue.